### PR TITLE
Improved mobile version with meta viewport, MQ and removed bug

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -5,7 +5,7 @@
 body {
 	margin: 10px;
 	padding: 5px;
-	width: 95%;
+	width: 98%;
 	font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 	color: #000;
 	font-size: 1rem; /* was 18px */
@@ -26,10 +26,11 @@ ul, ol {
 	list-style-position:inside;
 }
 
+/* dont apply this to ALL divs, just apply padding to the ones that need it */
 div {
 	/*border: 1px solid green;*/
-	padding: 5px;
-	width: auto;
+	/*padding: 5px;*/
+	/*width: auto;*/
 }
 
 section {
@@ -54,7 +55,8 @@ em {
 	width: 100%;
 }
 
-@media only screen and (min-width: 960px) {
+/* rems (ie root-ems) cascade their properties down to their children but ems dont - hence swopped 960px for 70rems */
+@media only screen and (min-width: 70rem) {
 	.graph_image {
 		width: 75%;
 	}
@@ -65,12 +67,22 @@ em {
 	font-size: 0.9rem;
 }
 
-/*parent contains child of logo and instructions*/
+/*parent contains child of logo and instructions - needs mq about 550 to center and take 100% width */
 .block_instructions {
+	margin-top: 10px;
 	/* differnce between flex & inline-flex ? */
 	display: flex;
 	flex-direction: row;
-	/*flex-wrap: wrap;*/
+	flex-wrap: wrap;
+	/* this is how to center an item within its parent */
+	/*justify-content: center;*/
+	/* this seems to center and adjust space to be equal around multiple items on same line, even when they flex/wrap to the below line */
+	justify-content: space-around;
+	width: 100%;
+}
+
+/* nothing required here at present */
+.core_logo {
 }
 
 /* need MQ to wrap children when browser is narrower ie change parent to flex-wrap = wrap, or why not use flex option from my portfolio ? */
@@ -80,8 +92,13 @@ em {
 	text-align: center;
 	background-color: #d1d2d4;
 	border: 1px solid gray;
+	width: 60%;
 }
-
+@media only screen and (max-width: 600px) {
+	.instructions {
+		width: 90%;
+	}
+}
 /*contents is overflowign, need to combine with flex grid below ? */
 .core_form {
 	border: 3px solid #4115c4;
@@ -94,26 +111,17 @@ em {
   /*border: 3px solid red;*/
 }
 
-/* need MQ to wrap children when browser is narrower ie change parent to flex-wrap = wrap, or why not use flex option from my portfolio ? */
-.instructions {
-	padding: 10px;
-	margin: 10px;
-	text-align: center;
-	background-color: #d1d2d4;
-	border: 1px solid gray;
-}
-
 /*contents is overflowign, need to combine with flex grid below ? */
-.core_form {
+/*.core_form {
 	border: 3px solid #4115c4;
 	background-color: #f7f5e3;
 	padding: 10px;
-}
+}*/
 
-.flex_container {
+/*.flex_container {
   display: flex; 
-  /*border: 3px solid brown;*/
-}
+  border: 3px solid brown;
+}*/
 
 /* flex boxes to line up Questions & Answers on Form */
 .flex-parent-qa {
@@ -131,17 +139,19 @@ em {
 }
 
 .flex-child-qa-questions {
-	width: 40%;
+	width: 60%;
 	border: 1px solid gray;
+	padding: 5px;
 }
 
 .flex-child-qa-answers {
-	width: 60%;
+	width: 40%;
 	border: 1px solid gray;
+	padding: 5px;
 }
 
-/* writing 500px makes this actually change/flex about 400px but why? */
-@media only screen and (max-width: 500px) {
+/* writing 500px makes this actually change/flex about 400px but why? - use rems instead of px, 30 rem is approx 450px tho depends on font size etc - othe rem sizes to try are 25, 35, 50, 70 */
+@media only screen and (max-width: 30rem) {
 	.flex-child-qa {
 		width: 100%;
 		font-size: 0.9rem;

--- a/src/Controllers/QuestionFormController.php
+++ b/src/Controllers/QuestionFormController.php
@@ -29,7 +29,7 @@ class QuestionFormController
 	{	
 		// add session stuff here
 		session_start(); 
-		echo session_id();
+		// echo session_id();
 
 		//if user not logged in ie no current session, redirect to home page
 		if ( !$_SESSION['coreIsLoggedIn']) {

--- a/templates/question_form.php
+++ b/templates/question_form.php
@@ -1,14 +1,16 @@
 <!DOCTYPE html>
 <html lang="en">
-<html>
 <!-- Davin updated this file for CoreQuestions -->
 <head>
-	<meta charset="utf-8"/>
+	<meta charset="utf-8" />
 	<title>Wellbeing Tracker - Answer Form</title>
 	<link href="../style.css" type="text/css" rel="stylesheet">
 	<!-- <link href="style.css" type="text/css" rel="stylesheet"> -->
-	<link href='//fonts.googleapis.com/css?family=Lato:400' rel='stylesheet' type='text/css'>
+	<link href='//fonts.googleapis.com/css?family=Lato:400' rel='stylesheet' type='text/css' />
+	<!-- needed for mobile devices/mq etc -->
+	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 </head>
+
 
 <body>
 	<h1>Wellbeing Tracker - Answer Wellbeing Questions</h1>
@@ -23,19 +25,19 @@
 
 	<!-- success msg if answeres to questions are saved ok -->
 	<?php  
-		echo session_id(); 
+		// echo session_id(); 
 
 		if ( isset($_GET['success']) && $_GET['success']== 1) {
 			echo '<em>Your Answers have been Saved</em>';
 		} 
 		if ( isset($_SESSION) )  {
-			var_dump("<br>session contents vardump: <br>");
-			var_dump($_SESSION); //this is null now?
+			// var_dump("<br>session contents vardump: <br>");
+			// var_dump($_SESSION); //this is null now?
 		}
-		echo session_id();
+		// echo session_id();
 	?>
 
-	<div class="core_form flex_container">
+	<div class="core_form">
 
 		<!-- Added date and name to form here - values are extracted as part of SaveAnswersController - OR should whole form be under a /userid route?-->
 
@@ -111,36 +113,47 @@
 							<!-- These are the Answer Labels for each question ie "Not At All, Only Occassionally, Sometimes, Often, Most or All the Time".
 								Question Answer Labels are now being retrieved from DB via QuestionModel.
 								TODO - consider having just one set of Answer Labels in a top-most Heading column, but would need each radio button to be in its own collumn -->
-							<label>
-								<input type="radio" required
-								name="radioAnswerPoints[<?php echo $q_id ?>]" 
-								value="<?php echo $singleQuestionPoints["pointsA_not"] ?>">
-								<?php echo $questionAnswerLabels[0]['label']; ?> 
-							</label>
-							<label>
-								<input type="radio"
-								name="radioAnswerPoints[<?php echo $q_id ?>]" 
-								value="<?php echo $singleQuestionPoints["pointsB_only"] ?>">
-								<?php echo $questionAnswerLabels[1]['label']; ?>
-							</label>
-							<label>
-								<input type="radio"
-								name="radioAnswerPoints[<?php echo $q_id ?>]" 
-								value="<?php echo $singleQuestionPoints["pointsC_sometimes"] ?>">
-								<?php echo $questionAnswerLabels[2]['label']; ?>
-							</label>
-							<label>
-								<input type="radio"
-								name="radioAnswerPoints[<?php echo $q_id ?>]" 
-								value="<?php echo $singleQuestionPoints["pointsD_often"] ?>">
-								<?php echo $questionAnswerLabels[3]['label']; ?>
-							</label>
-							<label>
-								<input type="radio"
-								name="radioAnswerPoints[<?php echo $q_id ?>]" 
-								value="<?php echo $singleQuestionPoints["pointsE_most"] ?>">
-								<?php echo $questionAnswerLabels[4]['label']; ?>
-							</label>
+							<div>
+								<label>
+									<input type="radio" required
+									name="radioAnswerPoints[<?php echo $q_id ?>]" 
+									value="<?php echo $singleQuestionPoints["pointsA_not"] ?>">
+									<?php echo $questionAnswerLabels[0]['label']; ?> 
+								</label>
+							</div>
+							<div>
+								<label>
+									<input type="radio"
+									name="radioAnswerPoints[<?php echo $q_id ?>]" 
+									value="<?php echo $singleQuestionPoints["pointsB_only"] ?>">
+									<?php echo $questionAnswerLabels[1]['label']; ?>
+								</label>
+							</div>
+							<div>
+								<label>
+									<input type="radio"
+									name="radioAnswerPoints[<?php echo $q_id ?>]" 
+									value="<?php echo $singleQuestionPoints["pointsC_sometimes"] ?>">
+									<?php echo $questionAnswerLabels[2]['label']; ?>
+								</label>
+							</div>
+							<div>
+								<label>
+									<input type="radio"
+									name="radioAnswerPoints[<?php echo $q_id ?>]" 
+									value="<?php echo $singleQuestionPoints["pointsD_often"] ?>">
+									<?php echo $questionAnswerLabels[3]['label']; ?>
+								</label>
+							</div>
+							<div>
+								<label>
+									<input type="radio"
+									name="radioAnswerPoints[<?php echo $q_id ?>]" 
+									value="<?php echo $singleQuestionPoints["pointsE_most"] ?>">
+									<?php echo $questionAnswerLabels[4]['label']; ?>
+								</label>
+							</div>
+
 						</div>	
 
 					<?php
@@ -157,7 +170,7 @@
 					<button name="btnSubmitAnswers" type="submit" class="submitButton">Submit Answers</button>
 				</div>
 
-				<p class="copyright">© CORE System Trust: https://www.coresystemtrust.org.uk/copyright.pdf</p>
+				<p class="copyright"><a href="https://www.coresystemtrust.org.uk/copyright.pdf">© CORE System Trust</a></p>
 
 			</form>
 


### PR DESCRIPTION
- css - adjusted width & formatting of MQ for QuestionForm, including using rems instead of px for device width; removed duplicate classes
- question_form - added meta viewport; removed vardump/echos; put each radio button on its own line using divs; made copyright text into link
- Controller - removed echo as it was outputted before first html tag and thus caused bug of head tag being completely empty